### PR TITLE
Add GH workflow for interactive fat jar

### DIFF
--- a/.github/workflows/build-interactive-fatjar.yml
+++ b/.github/workflows/build-interactive-fatjar.yml
@@ -1,0 +1,83 @@
+name: Build interactive fat jar
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: { contents: read }
+    env:
+      GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2-
+
+      - name: Inject Tycho 3.0.4
+        run: |
+          mkdir -p .mvn
+          cat <<'XML' > .mvn/extensions.xml
+          <extensions>
+            <extension>
+              <groupId>org.eclipse.tycho</groupId>
+              <artifactId>tycho-maven-plugin</artifactId>
+              <version>3.0.4</version>
+            </extension>
+          </extensions>
+          XML
+
+      - name: Build interactive fat jar
+        run: |
+          ./mvnw -B \
+            -pl org.omg.sysml.interactive -am \
+            -Pstandalone \
+            -DskipTests \
+            -Dtycho.executionEnvironment=JavaSE-21 \
+            package
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sysml-interactive-fatjar
+          path: org.omg.sysml.interactive/target/*-all.jar
+
+      - name: Publish to GitHub Packages
+        if: env.GH_PACKAGES_PAT != ''
+        env:
+          GH_PACKAGES_PAT: ${{ env.GH_PACKAGES_PAT }}
+        run: |
+          mkdir -p ~/.m2
+          cat <<'XML' > ~/.m2/settings.xml
+          <settings>
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${{ github.actor }}</username>
+                <password>${GH_PACKAGES_PAT}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
+          ./mvnw -B \
+            -pl org.omg.sysml.interactive -am \
+            -Pstandalone \
+            -DskipTests \
+            -Dtycho.executionEnvironment=JavaSE-21 \
+            deploy


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the interactive fat jar

## Testing
- `python3 - <<'PY'
import yaml
yaml.safe_load(open('.github/workflows/build-interactive-fatjar.yml'))
print('ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6875564ddfc08332beb53e961412b6a1